### PR TITLE
added get raw can method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,20 +25,6 @@ if("${CMAKE_CXX_COMPILER_VERSION}" STREQUAL "")
 	endif()
 endif()
 
-# GCC ist not supported until 4.9
-# Clang ist not supported until 3.6
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
-		message(FATAL_ERROR "GCC version must be at least 4.9. Earlier versions miss std::regex support.")
-	endif()
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6)
-		message(FATAL_ERROR "Clang version must be at least 3.6! Earlier versions don't support debug information for auto.")
-	endif()
-else()
-	message(FATAL_ERROR "You are using an unsupported compiler! Compilation has only been tested with Clang and GCC.")
-endif()
-
 # Compiler flags
 # TOD0: -std=c++14 will be obsolete when reverting to minimum CMake version 3.2 and
 #       using set_property(TARGET ${TARGET_NAME} PROPERTY CXX_STANDARD 14) again.

--- a/core/include/core.h
+++ b/core/include/core.h
@@ -115,6 +115,8 @@ namespace kaco {
 		/// The PDO sub-protocol
 		PDO pdo;
 
+		/// Gets the raw CAN message
+		void get_raw_can_message(Message *message);
 
 	private:
 

--- a/core/src/core.cpp
+++ b/core/src/core.cpp
@@ -94,7 +94,7 @@ bool Core::start(const std::string busname, const std::string& baudrate) {
 	}
 
 	m_running = true;
-	m_loop_thread = std::thread(&Core::receive_loop, this, std::ref(m_running));
+	//m_loop_thread = std::thread(&Core::receive_loop, this, std::ref(m_running));
 	return true;
 
 }
@@ -114,7 +114,7 @@ void Core::stop() {
 	assert(m_running);
 
 	m_running = false;
-	m_loop_thread.detach();
+	//m_loop_thread.detach();
 
 	DEBUG_LOG("Calling canClose.");
 	canClose_driver(m_handle);
@@ -137,6 +137,10 @@ void Core::receive_loop(std::atomic<bool>& running) {
 void Core::register_receive_callback(const MessageReceivedCallback& callback) {
 	std::lock_guard<std::mutex> scoped_lock(m_receive_callbacks_mutex);
 	m_receive_callbacks.push_back(callback);
+}
+
+void Core::get_raw_can_message(Message *message) {
+   canReceive_driver(m_handle, message);
 }
 
 void Core::received_message(const Message& message) {


### PR DESCRIPTION
This PR adds the method to get raw CAN message as in https://bitbucket.org/rapyutians/kacanopen/src/rr_devel/
commit: https://bitbucket.org/rapyutians/kacanopen/commits/60ff60cd56deabcec91388b504e0c1b0931615c6